### PR TITLE
remove package dependency on MinVer

### DIFF
--- a/src/EventAggregator.Blazor.csproj
+++ b/src/EventAggregator.Blazor.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.2" />
-    <PackageReference Include="MinVer" Version="2.2.0" />
+    <PackageReference Include="MinVer" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
   
   <Target Name="CopyMissingBlazorContent" BeforeTargets="BlazorCompleteStandalonePublish">


### PR DESCRIPTION
Currently the package has a runtime dependency on MinVer.

![image](https://user-images.githubusercontent.com/677704/135607573-82ab5fcd-f296-44f3-8eed-3ef2ab1c06b6.png)

Unless you are producing some kind of MinVer extension or aggregator package, the MinVer package should not be a runtime dependency. It should be a development time dependency only.

This change makes MinVer a development time dependency only.